### PR TITLE
Fix stow conflicts with existing config files

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
 ln -sf "$ICLOUD/secrets/.secrets" "$HOME/.secrets"
 
 brew install stow
-cd "$DOTFILES" && stow --adopt brew ghostty git zed zsh && git checkout .
+cd "$DOTFILES" && stow --adopt brew ghostty git zed zsh && git restore .
 source "$HOME/.zshenv"
 
 brew bundle --global

--- a/install.sh
+++ b/install.sh
@@ -13,7 +13,7 @@ ICLOUD="$HOME/Library/Mobile Documents/com~apple~CloudDocs"
 ln -sf "$ICLOUD/secrets/.secrets" "$HOME/.secrets"
 
 brew install stow
-cd "$DOTFILES" && stow brew ghostty git zed zsh
+cd "$DOTFILES" && stow --adopt brew ghostty git zed zsh && git checkout .
 source "$HOME/.zshenv"
 
 brew bundle --global


### PR DESCRIPTION
stow --adopt moves existing files into the package dir (resolving
conflicts), then git checkout . restores the repo versions so the
dotfiles always win.

https://claude.ai/code/session_01Vg2NgwiEGC1Hg9cW1fjgz5