### PR TITLE
Set adjust-cell-height to 30% in Ghostty config

### DIFF
--- a/ghostty/.config/ghostty/config
+++ b/ghostty/.config/ghostty/config
@@ -1,1 +1,2 @@
 theme = dark:Hipster Green,light:Builtin Light
+adjust-cell-height = 30%


### PR DESCRIPTION
Adjusts the cell height in Ghostty terminal to 30% for better visual appearance.

https://claude.ai/code/session_01DLQixJG8eKcmvcDuo3ohra