### PR TITLE
Set Homebrew auto-update interval to 12 hours

### DIFF
--- a/zsh/.zshenv
+++ b/zsh/.zshenv
@@ -4,6 +4,7 @@ typeset -U path
 
 export XDG_CONFIG_HOME="$HOME/.config"
 export EDITOR='vim'
+export HOMEBREW_AUTO_UPDATE_SECS=43200
 
 if command -v fnm &>/dev/null; then
     eval "$(fnm env --use-on-cd --shell zsh)"


### PR DESCRIPTION
### Motivation
- Reduce Homebrew auto-update frequency by configuring it to run at most every 12 hours to avoid excessive background update checks while keeping packages reasonably fresh.

### Description
- Exported `HOMEBREW_AUTO_UPDATE_SECS=43200` in `zsh/.zshenv` to set Homebrew's auto-update interval to 12 hours.

### Testing
- Attempted a shell syntax check with `zsh -n zsh/.zshenv`, but it could not be run because `zsh` is not installed in this environment.
- No additional automated tests were required for this one-line environment variable change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69921c90c95c832b9f3725ad46b42192)